### PR TITLE
Allow user to configure ROS output location

### DIFF
--- a/lex_node/launch/lex_node.launch
+++ b/lex_node/launch/lex_node.launch
@@ -3,6 +3,7 @@
     <arg name="node_name" default="lex_node" />
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
     <arg name="config_file" default="" />
+    <!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
     <arg name="output" default="log" />
 
     <node name="$(arg node_name)" pkg="lex_node" type="lex_node" output="$(arg output)">

--- a/lex_node/launch/lex_node.launch
+++ b/lex_node/launch/lex_node.launch
@@ -3,8 +3,9 @@
     <arg name="node_name" default="lex_node" />
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
     <arg name="config_file" default="" />
+    <arg name="output" default="log" />
 
-    <node name="$(arg node_name)" pkg="lex_node" type="lex_node">
+    <node name="$(arg node_name)" pkg="lex_node" type="lex_node" output="$(arg output)">
         <!-- If the caller specified a config file then load it here. -->
         <rosparam if="$(eval config_file!='')" command="load" file="$(arg config_file)"/>
     </node>


### PR DESCRIPTION
This allows the user to send output to their screen instead of the default of 'log' when including the lex_node.launch file inside their own launch file. 

`log` is the default output value when it's not set (see http://wiki.ros.org/roslaunch/XML/node)

Tested by running voice interaction sample application passing in the output value of 'screen' instead of the default, and output started being written to the terminal as expected. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
