### PR TITLE
Restrict dependencies to specific versions

### DIFF
--- a/lex_node/package.xml
+++ b/lex_node/package.xml
@@ -15,8 +15,8 @@
 
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
-  <depend>lex_common_msgs</depend>
-  <depend>aws_common</depend>
-  <depend>aws_ros1_common</depend>
+  <depend version_lt='2.0.0'>lex_common_msgs</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_ros1_common</depend>
   <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
*Description of changes:*
Sets aws-robotics dependencies to less than 2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
