### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/lex_node/src/lex_param_helper.cpp
+++ b/lex_node/src/lex_param_helper.cpp
@@ -16,6 +16,9 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <lex_node/lex_param_helper.h>
 
+using Aws::Client::ParameterPath;
+
+
 namespace Aws {
 namespace Lex {
 
@@ -23,9 +26,9 @@ LexConfiguration LoadLexParameters(const Client::ParameterReaderInterface & para
 {
   LexConfiguration lex_configuration;
   bool is_invalid = false;
-  is_invalid |= (bool)parameter_interface.ReadStdString(kBotAliasKey, lex_configuration.bot_alias);
-  is_invalid |= (bool)parameter_interface.ReadStdString(kBotNameKey, lex_configuration.bot_name);
-  is_invalid |= (bool)parameter_interface.ReadStdString(kUserIdKey, lex_configuration.user_id);
+  is_invalid |= static_cast<bool>(parameter_interface.ReadParam(ParameterPath(kBotAliasKey), lex_configuration.bot_alias));
+  is_invalid |= static_cast<bool>(parameter_interface.ReadParam(ParameterPath(kBotNameKey), lex_configuration.bot_name));
+  is_invalid |= static_cast<bool>(parameter_interface.ReadParam(ParameterPath(kUserIdKey), lex_configuration.user_id));
   if (is_invalid) {
     AWS_LOG_INFO(__func__, "Lex configuration not fully specified");
     throw std::invalid_argument("Lex configuration not fully specified");

--- a/lex_node/test/lex_node_test.cpp
+++ b/lex_node/test/lex_node_test.cpp
@@ -117,9 +117,10 @@ public:
                    {"aws_client_configuration/region", "us-west-2"}};
   }
 
-  AwsError ReadInt(const char * name, int & out) const
+  AwsError ReadParam(const ParameterPath & param_path, int & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (int_map_.count(name) > 0) {
       out = int_map_.at(name);
       result = AWS_ERR_OK;
@@ -127,14 +128,15 @@ public:
     return result;
   }
 
-  AwsError ReadBool(const char * name, bool & out) const
+  AwsError ReadParam(const ParameterPath & param_path, bool & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadStdString(const char * name, std::string & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::string & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (string_map_.count(name) > 0) {
       out = string_map_.at(name);
       result = AWS_ERR_OK;
@@ -142,9 +144,10 @@ public:
     return result;
   }
   
-  AwsError ReadString(const char * name, String & out) const
+  AwsError ReadParam(const ParameterPath & param_path, String & out) const
   {
     AwsError result = AWS_ERR_NOT_FOUND;
+    std::string name = FormatParameterPath(param_path);
     if (string_map_.count(name) > 0) {
       out = string_map_.at(name).c_str();
       result = AWS_ERR_OK;
@@ -152,23 +155,23 @@ public:
     return result;
   }
   
-  AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
   
-  AwsError ReadList(const char * name, std::vector<std::string> & out) const
+  AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
-  AwsError ReadDouble(const char * name, double & out) const
+  AwsError ReadParam(const ParameterPath & param_path, double & out) const
   {
     return AWS_ERR_NOT_FOUND;
   }
 
 private:
-  std::string FormatParameterPath(const Client::ParameterPath & param_path) const
+  std::string FormatParameterPath(const ParameterPath & param_path) const
   {
     return param_path.get_resolved_path(PARAM_NS_SEPARATOR_CHAR, PARAM_NS_SEPARATOR_CHAR);
   }


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
