### PR TITLE
enforce code coverage to not drop below baseline code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    # doc: https://docs.codecov.io/docs/commit-status
+    project:
+      default:
+        # will use the coverage from the base commit (pull request base or parent commit) coverage to compare against.
+        target: auto
+        threshold: null
+        # will use the pull request base if the commit is on a pull request. If not, the parent commit will be used.
+        base: auto


### PR DESCRIPTION
Test:
https://github.com/aws-robotics/cloudwatchmetrics-ros1/pull/23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
